### PR TITLE
Use simplematrixbotlib package from repo not pypi (sphinx autodoc)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,9 +10,13 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
+import os
+import sys
 # sys.path.insert(0, os.path.abspath('.'))
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+
 import sphinx_rtd_theme
 
 # -- Project information -----------------------------------------------------

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,1 @@
 m2r2
-simplematrixbotlib


### PR DESCRIPTION
autodoc will now import the simplematrixbotlib package from the directory above the doc dir, instead of installing it from pypi