### PR TITLE
Listener rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 venv/
 doc/_build/
 .devcontainer/
+__pycache__
+simplematrixbotlib/__pycache__
+simplematrixbotlib/*/__pycache__
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Simple-Matrix-Bot-Lib
-(Version 1.5.x)
+(Version 1.6.x)
 
 Simple-Matrix-Bot-Lib is a Python bot library for the Matrix ecosystem built on [matrix-nio](https://github.com/poljar/matrix-nio).
 
@@ -69,6 +69,20 @@ More examples can be found [here](examples).
         if not message.sender == bot.async_client.user_id: #Optional, prevents the bot from reacting to its own messages
             await bot.api.send_text_message(room.room_id, "something") #Send a message containing "something" to room
     bot.add_message_listener(say_something_to_a_message_not_from_bot) #Listen for messages, can have as many message listeners as needed, each added using bot.add_message_listener
+
+    bot.run()
+    ```
+- ### Send images - bot can send image messages
+    ```python
+    import simplematrixbotlib as botlib
+    
+    creds = botlib.Creds("https://home.server", "user", "pass")
+    bot = botlib.Bot(creds)
+
+    async def send_image_to_a_message_not_from_bot(room, message):
+        if not message.sender == bot.async_client.user_id:
+            await bot.api.send_image_message(room.room_id, "./example.png") #Send the image file located at ./example.png to room
+    bot.add_message_listener(send_image_to_a_message_not_from_bot)
 
     bot.run()
     ```

--- a/README.md
+++ b/README.md
@@ -8,19 +8,24 @@ Simple-Matrix-Bot-Lib is a Python bot library for the Matrix ecosystem built on 
 
 Learn how you can contribute [here](CONTRIBUTING.md).
 
-
 # Installation
+
 ### To use it, simplematrixbotlib can be either installed from PyPi or downloaded from github.</br>
+
 Installation from PyPi:
+
 ```
 python -m pip install simplematrixbotlib
 ```
+
 Download from github:
+
 ```
 git clone --branch master https://github.com/KrazyKirby99999/simple-matrix-bot-lib.git
 ```
 
 # Example Usage
+
 ```python
 import simplematrixbotlib as botlib
 import os
@@ -30,6 +35,7 @@ bot = botlib.Bot(creds)
 
 prefix = '!'
 
+@bot.listener.on_message_event
 async def echo(room, message):
     """
     Example function that "echoes" arguements.
@@ -41,37 +47,43 @@ async def echo(room, message):
     if match.not_from_this_bot() and match.prefix(prefix) and match.command("echo"):
         await bot.api.send_text_message(room.room_id, match.args)
 
-bot.add_message_listener(echo)
-
 bot.run()
 ```
+
 More examples can be found [here](examples).
 
 # Features
+
 ## Complete:
-- ### Login to homeserver - bot automatically login upon the execution of bot.run() 
-    ```python
-    import simplematrixbotlib as botlib
-    
-    creds = botlib.Creds("home.server", "user", "pass")
-    bot = botlib.Bot(creds)
-    bot.run() #Logs in during the execution of this line
-    ```
+
+- ### Login to homeserver - bot automatically login upon the execution of bot.run()
+  
+  ```python
+  import simplematrixbotlib as botlib
+  
+  creds = botlib.Creds("home.server", "user", "pass")
+  bot = botlib.Bot(creds)
+  bot.run() #Logs in during the execution of this line
+  ```
+
 - ### Join room on invite - bot automatically join rooms that the bot is invited to upon execution of bot.run(), or upon invite if the bot is running
+
 - ### Send message - bot can send messages in response to other messages, and can also run other code in response to messages as well as filter the messages that the bot responds to
-    ```python
-    import simplematrixbotlib as botlib
-    
-    creds = botlib.Creds("https://home.server", "user", "pass")
-    bot = botlib.Bot(creds)
+  
+  ```python
+  import simplematrixbotlib as botlib
+  
+  creds = botlib.Creds("https://home.server", "user", "pass")
+  bot = botlib.Bot(creds)
+  
+  @bot.listener.on_message_event #Listen for messages, can have as many message listeners as needed, each added using @bot.listener.on_message_event
+  async def say_something_to_a_message_not_from_bot(room, message): #Must be an "async" function with (room, message) arguments
+      if not message.sender == bot.async_client.user_id: #Optional, prevents the bot from reacting to its own messages
+          await bot.api.send_text_message(room.room_id, "something") #Send a message containing "something" to room
+  
+  bot.run()
+  ```
 
-    async def say_something_to_a_message_not_from_bot(room, message): #Must be an "async" function with (room, message) arguments
-        if not message.sender == bot.async_client.user_id: #Optional, prevents the bot from reacting to its own messages
-            await bot.api.send_text_message(room.room_id, "something") #Send a message containing "something" to room
-    bot.add_message_listener(say_something_to_a_message_not_from_bot) #Listen for messages, can have as many message listeners as needed, each added using bot.add_message_listener
-
-    bot.run()
-    ```
 - ### Send images - bot can send image messages
     ```python
     import simplematrixbotlib as botlib
@@ -79,97 +91,108 @@ More examples can be found [here](examples).
     creds = botlib.Creds("https://home.server", "user", "pass")
     bot = botlib.Bot(creds)
 
+    @bot.listener.on_message_event
     async def send_image_to_a_message_not_from_bot(room, message):
         if not message.sender == bot.async_client.user_id:
             await bot.api.send_image_message(room.room_id, "./example.png") #Send the image file located at ./example.png to room
-    bot.add_message_listener(send_image_to_a_message_not_from_bot)
 
     bot.run()
     ```
+
 - ### Execute action based on criteria - "match filters" can be used to  specify which messages for the bot to respond to
-    ```python
-    import simplematrixbotlib as botlib
-    import os
+  
+  ```python
+  import simplematrixbotlib as botlib
+  import os
+  
+  creds = botlib.Creds("https://home.server", "user", "pass")
+  bot = botlib.Bot(creds)
+  
+  prefix = '!' #Create prefix for commands
+  
+  @bot.listener.on_message_event
+  async def echo(room, message):
+      """
+      Example function that "echoes" arguements.
+      Usage:
+      example_user- !echo say something
+      echo_bot- say something
+      """
+      match = botlib.MessageMatch(room, message, bot) #Create an object of the botlib.MessageMatch class
+      if match.not_from_this_bot() and match.prefix(prefix) and match.command("echo"): #Add match filters
+          await bot.api.send_text_message(room.room_id, match.args)#Execute action
+  
+  bot.run()
+  ```
 
-    creds = botlib.Creds("https://home.server", "user", "pass")
-    bot = botlib.Bot(creds)
-
-    prefix = '!' #Create prefix for commands
-
-    async def echo(room, message):
-        """
-        Example function that "echoes" arguements.
-        Usage:
-        example_user- !echo say something
-        echo_bot- say something
-        """
-        match = botlib.MessageMatch(room, message, bot) #Create an object of the botlib.MessageMatch class
-        if match.not_from_this_bot() and match.prefix(prefix) and match.command("echo"): #Add match filters
-            await bot.api.send_text_message(room.room_id, match.args)#Execute action
-    bot.add_message_listener(echo)
-
-    bot.run()
-    ```
 - ### Preserve sessions - Sessions are now preserved between logins. The access token and device id are now saved in sessions.txt, unless specified otherwise.
-    ```python
-    import simplematrixbotlib as botlib
-    import os
+  
+  ```python
+  import simplematrixbotlib as botlib
+  import os
+  
+  creds = botlib.Creds("https://home.server", "user", "pass", None) #Disable preserved sessions
+  bot = botlib.Bot(creds)
+  
+  prefix = '!'
+  
+  @bot.listener.on_message_event
+  async def echo(room, message):
+      """
+      Example function that "echoes" arguements.
+      Usage:
+      example_user- !echo say something
+      echo_bot- say something
+      """
+      match = botlib.MessageMatch(room, message, bot)
+      if match.not_from_this_bot() and match.prefix(prefix) and match.command("echo"):
+          await bot.api.send_text_message(room.room_id, match.args)
+  
+  bot.run()
+  ```
 
-    creds = botlib.Creds("https://home.server", "user", "pass", None) #Disable preserved sessions
-    bot = botlib.Bot(creds)
-
-    prefix = '!'
-
-    async def echo(room, message):
-        """
-        Example function that "echoes" arguements.
-        Usage:
-        example_user- !echo say something
-        echo_bot- say something
-        """
-        match = botlib.MessageMatch(room, message, bot)
-        if match.not_from_this_bot() and match.prefix(prefix) and match.command("echo"):
-            await bot.api.send_text_message(room.room_id, match.args)
-    bot.add_message_listener(echo)
-
-    bot.run()
-    ```
 - ### Add choice of actions to execute at bot login - Execute action after logging in
-    ```python
-    import simplematrixbotlib as botlib
-    import os
-
-    creds = botlib.Creds("https://home.server", "random_bot", "pass")
-    bot = botlib.Bot(creds)
-
-    prefix = '!'
-
-    async def hello(room_id): #Must be an "async" function with a (room_id) argument
-        """
-        Example function that says "hello" when the bot is started.
-        Usage:
-        (start random_bot)
-        random_bot - hello
-        """
-        message = "hello"
-        await bot.api.send_text_message(room_id, message) #Example of sending a message
-
-    bot.add_startup_action(hello) #Add "hello" action to action to execute at login
-
-    bot.run()
-    ```
+  
+  ```python
+  import simplematrixbotlib as botlib
+  import os
+  
+  creds = botlib.Creds("https://home.server", "random_bot", "pass")
+  bot = botlib.Bot(creds)
+  
+  prefix = '!'
+  
+  async def hello(room_id): #Must be an "async" function with a (room_id) argument
+      """
+      Example function that says "hello" when the bot is started.
+      Usage:
+      (start random_bot)
+      random_bot - hello
+      """
+      message = "hello"
+      await bot.api.send_text_message(room_id, message) #Example of sending a message
+  
+  bot.add_startup_action(hello) #Add "hello" action to action to execute at login
+  
+  bot.run()
+  ```
 
 ## In Progress:
+
 - ### Add more examples
 - ### Improve Documentation
 
 ## Planned:
+
 - ### Add more match filters
 - ### Support for Encrypted Rooms
 - ### More
 
 # Dependencies
+
 ## Python:
+
 - ### matrix-nio >= 0.18.2
-## External:
+  
+  ## External:
 - ### Python >= 3.7

--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ More examples can be found [here](examples).
   bot = botlib.Bot(creds)
   
   prefix = '!'
-  
+
+  @bot.listener.on_startup #Add "hello" action to action to execute at login
   async def hello(room_id): #Must be an "async" function with a (room_id) argument
       """
       Example function that says "hello" when the bot is started.
@@ -171,8 +172,7 @@ More examples can be found [here](examples).
       """
       message = "hello"
       await bot.api.send_text_message(room_id, message) #Example of sending a message
-  
-  bot.add_startup_action(hello) #Add "hello" action to action to execute at login
+
   
   bot.run()
   ```

--- a/doc/autodoc.rst
+++ b/doc/autodoc.rst
@@ -17,6 +17,13 @@ Bot
     :members:
     :undoc-members:
 
+Listener
+---
+
+.. autoclass:: simplematrixbotlib.Listener
+    :members:
+    :undoc-members:
+
 MessageMatch
 ------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,7 +22,7 @@ copyright = '2021, KrazyKirby99999'
 author = 'KrazyKirby99999'
 
 # The full version, including alpha/beta/rc tags
-release = '1.5.2'
+release = '1.5.3'
 
 # -- General configuration ---------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,7 +22,7 @@ copyright = '2021, KrazyKirby99999'
 author = 'KrazyKirby99999'
 
 # The full version, including alpha/beta/rc tags
-release = '1.5.3'
+release = '1.6.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,7 +22,7 @@ copyright = '2021, KrazyKirby99999'
 author = 'KrazyKirby99999'
 
 # The full version, including alpha/beta/rc tags
-release = '1.6.0'
+release = '1.6.1'
 
 # -- General configuration ---------------------------------------------------
 

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -20,6 +20,10 @@ This is a manual for simplematrixbotlib that includes documentation, examples, a
 
 .. mdinclude:: manual/bot.md
 
+## Usage of Listener class
+
+.. mdinclude:: manual/listener.md
+
 ## Usage of MessageMatch class
 
 .. mdinclude:: manual/messagematch.md

--- a/doc/manual/api.md
+++ b/doc/manual/api.md
@@ -20,3 +20,16 @@ async def example(room, message):
             message=example_message)
 ```
 Both arguments are required. The room_id argument is the id of the destination room. The message argument is the string that is to be sent as a message.
+
+### Using the send_image_message method
+The send_image_message method of the Api class can be used to send image messages in Matrix rooms. An example is shown in the following python code.
+```python
+async def example(room, message):
+    match = botlib.MessageMatch(room, message, bot)
+    example_image="./img/example.png"
+    if match.not_from_this_bot():
+        bot.api.send_image_message(
+            room_id=room.room_id, 
+            image_filepath=example_image)
+```
+Both arguments are required. The room_id argument is the id of the destination room. The image_filepath argument is a string that is the path to the image file that is to be sent as a message.

--- a/doc/manual/bot.md
+++ b/doc/manual/bot.md
@@ -10,15 +10,6 @@ bot = botlib.Bot(
 ```
 The creds argument is neccesary, and is an instance of the Creds class.
 
-#### Using the add_startup_action method
-The add_startup_action method of the Bot class may be used to execute actions upon the starting of the Bot. Example usage of the add_startup_action method is show in the following python code.
-```python
-async def room_joined(room_id):
-    print(f"This account is a member of a room with the id {room_id}")
-bot.add_startup_listener(room_joined)
-```
-When the bot is run, for each room that the Bot is a member of, the function will be called with room_id as a string that corresponds to the room_id of the room.
-
 #### Running the Bot
 When the Bot is ready to be started, the run method can be used to run the Bot. An example is shown in the following python code.
 ```

--- a/doc/manual/bot.md
+++ b/doc/manual/bot.md
@@ -10,15 +10,6 @@ bot = botlib.Bot(
 ```
 The creds argument is neccesary, and is an instance of the Creds class.
 
-#### Using the add_message_listener method
-The add_message_listener method of the Bot class may be used to execute actions based on messages that are sent in rooms that the bot is a member of. Example usage of add_message_listener is shown in the following python code.
-```python
-async def example(room, message):
-    print(f"A message({message.content}) was sent in a room({room.room_id}).")
-bot.add_message_listener(example)
-```
-When any message is sent, the function will be called with room as a [Room object](https://matrix-nio.readthedocs.io/en/latest/nio.html#nio.rooms.MatrixRoom) representing each room that that the bot is a member of, and message as a [RoomMessage object](https://matrix-nio.readthedocs.io/en/latest/nio.html?highlight=nio.events.room_events.roommessage.content#nio.events.room_events.RoomMessage) representing the message that was sent.
-
 #### Using the add_startup_action method
 The add_startup_action method of the Bot class may be used to execute actions upon the starting of the Bot. Example usage of the add_startup_action method is show in the following python code.
 ```python

--- a/doc/manual/listener.md
+++ b/doc/manual/listener.md
@@ -9,7 +9,7 @@ bot.listener #Instance of the Listener class
 ```
 
 ### Using the on_message_event decorator
-The on_message_event method of the Bot class may be used to execute actions based on messages that are sent in rooms that the bot is a member of. Example usage of on_message_event is shown in the following python code.
+The on_message_event method of the Listener class may be used to execute actions based on messages that are sent in rooms that the bot is a member of. Example usage of on_message_event is shown in the following python code.
 ```python
 @bot.listener.on_message_event
 async def example(room, message):
@@ -19,7 +19,7 @@ async def example(room, message):
 When any message is sent, the function will be called with room as a [Room object](https://matrix-nio.readthedocs.io/en/latest/nio.html#nio.rooms.MatrixRoom) representing each room that that the bot is a member of, and message as a [RoomMessage object](https://matrix-nio.readthedocs.io/en/latest/nio.html?highlight=nio.events.room_events.roommessage.content#nio.events.room_events.RoomMessage) representing the message that was sent.
 
 ### Using the on_custom_event decorator
-The on_custom_event method of the Bot class may be used to execute actions based on any event that is sent in rooms that the bot is a member of. Example usage of on_custom_event is shown in the following python code.
+The on_custom_event method of the Listener class may be used to execute actions based on any event that is sent in rooms that the bot is a member of. Example usage of on_custom_event is shown in the following python code.
 ```python
 import nio
 
@@ -31,5 +31,13 @@ async def example(room, event):
         print(f"A user left the room({room.room_id}).")
 
 ```
-The on_custom_event method is identical to the on_message_event method, however on_custom_event takes an argument that allows the developer to specify the event type for the Bot to respond to. Information on events can be found in the [matrix-nio docs](https://matrix-nio.readthedocs.io/en/latest/nio.html#module-nio.events).
+The on_custom_event method is almost identical to the on_message_event method. on_custom_event takes an argument that allows the developer to specify the event type for the Bot to respond to. Information on events can be found in the [matrix-nio docs](https://matrix-nio.readthedocs.io/en/latest/nio.html#module-nio.events).
 
+#### Using the on_startup decorator
+The on_startup method of the Listener class may be used to execute actions upon the starting of the Bot. Example usage of the on_startup method is show in the following python code.
+```python
+@bot.listener.on_startup
+async def room_joined(room_id):
+    print(f"This account is a member of a room with the id {room_id}")
+```
+When the bot is run, for each room that the Bot is a member of, the function will be called with room_id as a string that corresponds to the room_id of the room.

--- a/doc/manual/listener.md
+++ b/doc/manual/listener.md
@@ -18,4 +18,18 @@ async def example(room, message):
 ```
 When any message is sent, the function will be called with room as a [Room object](https://matrix-nio.readthedocs.io/en/latest/nio.html#nio.rooms.MatrixRoom) representing each room that that the bot is a member of, and message as a [RoomMessage object](https://matrix-nio.readthedocs.io/en/latest/nio.html?highlight=nio.events.room_events.roommessage.content#nio.events.room_events.RoomMessage) representing the message that was sent.
 
+### Using the on_custom_event decorator
+The on_custom_event method of the Bot class may be used to execute actions based on any event that is sent in rooms that the bot is a member of. Example usage of on_custom_event is shown in the following python code.
+```python
+import nio
+
+@bot.listener.on_custom_event(nio.InviteMemberEvent)
+async def example(room, event):
+    if event.membership == "join":
+        print(f"A user joined the room({room.room_id}).")
+    if event.membership == "leave":
+        print(f"A user left the room({room.room_id}).")
+
+```
+The on_custom_event method is identical to the on_message_event method, however on_custom_event takes an argument that allows the developer to specify the event type for the Bot to respond to. Information on events can be found in the [matrix-nio docs](https://matrix-nio.readthedocs.io/en/latest/nio.html#module-nio.events).
 

--- a/doc/manual/listener.md
+++ b/doc/manual/listener.md
@@ -1,0 +1,21 @@
+### How to use the Listener class
+The Listener class is a class that is used to specify reactions to the events that occur in Matrix rooms. The source is located at simplematrixbotlib/listener.py
+
+### Accessing a Listener instance
+An instance of the Listener class is automatically created when an instance of the Bot class is created. An example is shown in the following python code.
+```python
+bot = botlib.Bot(creds)
+bot.listener #Instance of the Listener class
+```
+
+### Using the on_message_event decorator
+The on_message_event method of the Bot class may be used to execute actions based on messages that are sent in rooms that the bot is a member of. Example usage of on_message_event is shown in the following python code.
+```python
+@bot.listener.on_message_event
+async def example(room, message):
+    print(f"A message({message.content}) was sent in a room({room.room_id}).")
+
+```
+When any message is sent, the function will be called with room as a [Room object](https://matrix-nio.readthedocs.io/en/latest/nio.html#nio.rooms.MatrixRoom) representing each room that that the bot is a member of, and message as a [RoomMessage object](https://matrix-nio.readthedocs.io/en/latest/nio.html?highlight=nio.events.room_events.roommessage.content#nio.events.room_events.RoomMessage) representing the message that was sent.
+
+

--- a/doc/manual/messagematch.md
+++ b/doc/manual/messagematch.md
@@ -12,20 +12,20 @@ match = botlib.MessageMatch(
 ```
 All of the arguments are neccesary. The bot argument is an instance of the Bot class. The room and message arguments are the same as the arguments specified when creating a function to be used with the Bot.add_message_listener method. An example of the two combined is shown in the following python code.
 ```python
+bot.listener.on_message_event
 async def example(room, message):
     match = botlib.MessageMatch(room, message, bot)
-bot.add_message_listener(example)
 ```
 
 #### Using the prefix method
 The prefix method of the MessageMatch class can be used to filter by messages that begin with a specified prefix. Example usage of the MessageMatch.prefix method is shown in the following python code.
 ```python
 PREFIX = '!'
+bot.listener.on_message_event
 async def example(room, message):
     match = botlib.MessageMatch(room, message, bot)
     if match.prefix(PREFIX):
         #Do Something
-bot.add_message_listener(example)
 ```
 In this case, match.prefix(PREFIX) returns True if the message begins with the same value as the PREFIX variable.
 
@@ -33,32 +33,32 @@ In this case, match.prefix(PREFIX) returns True if the message begins with the s
 The command method of the MessageMatch class can be used to filter messages by the string that immediately follows the prefix of the message. The command method returns True if the string following the prefix begins with the command string. The args attribute of the MessageMatch object is set to a string that contains the original message, but with the command ommitted. It will also ommit the prefix if the prefix method was called before this method. An example is shown in the following python code.
 ```python
 PREFIX = '!'
+bot.listener.on_message_event
 async def example(room, message):
     match = botlib.MessageMatch(room, message, bot)
     COMMAND = "example"
     if (match.prefix(PREFIX) and #Returns True if the message begins with PREFIX
         match.command(COMMAND)): #Returns True if the message following the prefix begins with COMMAND
         print(match.args) #Prints the message, but without PREFIX and without COMMAND
-bot.add_message_listener(example)
 ```
 The command method will be improved, although with incompatable changes in the next major version of Simple-Major-Bot-Lib.
 
 #### Using the not_from_this_bot method
 The not_from_this_bot method of the MessageMatch class can be used to filter messages based on whether they come from Matrix users and not from this bot. not_from_this_bot returns True if the message sender is not the bot. An example is shown in the following python code.
 ```python
+bot.listener.on_message_event
 async def example(room, message):
     match = botlib.MessageMatch(room, message, bot)
     if match.not_from_this_bot: #Returns True if the message was sent by a different user
         #Do Something
-bot.add_message_listener(example)
 ```
 
 #### Using the contains method
 The contains method of the MessageMatch class can be used to filter messages based on whether a specified string is within the message body. An example is shown in the following python code.
 ```python
+bot.listener.on_message_event
 async def example(room,message):
     match = botlib.MessageMatch(room, message, bot)
     if match.contains("example string"): #Returns True if the message body contains "example string"
         #Do Something
-bot.add_message_listener(example)
 ```

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -51,6 +51,10 @@ If you want to use a prefix in the commands that your bot responds to, you may w
 ```python
 PREFIX = '!'
 ```
+Before creating a command, it is necessary to add a listener(callback) for the bot to use it.
+```python
+@bot.listener.on_message_event
+```
 Create a command by defining a function. The function must be an "async" function with (room, message) as the arguments.
 ```python
 async def echo(room, message): 
@@ -73,10 +77,6 @@ This part of the command is the part that "acts". The line provided sends a mess
 ```python
         await bot.api.send_text_message(room.room_id, match.args) 
 ```
-After creating a command, it is necessary to add a listener(callback) for the bot to use it.
-```python
-bot.add_message_listener(echo)
-```
 And finally run the bot.
 ```python
 bot.run()
@@ -93,6 +93,7 @@ bot = botlib.Bot(creds)
 
 PREFIX = '!'
 
+@bot.listener.on_message_event
 async def echo(room, message):
     """
     Example function that "echoes" arguements.
@@ -103,8 +104,6 @@ async def echo(room, message):
     match = botlib.MessageMatch(room, message, bot)
     if match.not_from_this_bot() and match.prefix(PREFIX) and match.command("echo"):
         await bot.api.send_text_message(room.room_id, match.args)
-
-bot.add_message_listener(echo)
 
 bot.run()
 ```

--- a/examples/echo.py
+++ b/examples/echo.py
@@ -16,14 +16,12 @@ bot = botlib.Bot(creds)
 
 prefix = '!'
 
-
+@bot.listener.on_message_event
 async def echo(room, message):
     match = botlib.MessageMatch(room, message, bot)
     if match.not_from_this_bot() and match.prefix(prefix) and match.command(
             "echo"):
         await bot.api.send_text_message(room.room_id, match.args)
 
-
-bot.add_message_listener(echo)
 
 bot.run()

--- a/examples/high_fives.py
+++ b/examples/high_fives.py
@@ -34,6 +34,7 @@ except FileNotFoundError:
     bot.total_high_fives = 0
 
 
+@bot.listener.on_message_event
 async def bot_help(room, message):
     bot_help_message = f"""
     Help Message:
@@ -55,9 +56,7 @@ async def bot_help(room, message):
         await bot.api.send_text_message(room.room_id, bot_help_message)
 
 
-bot.add_message_listener(bot_help)
-
-
+@bot.listener.on_message_event
 async def high_five(room, message):
     match = botlib.MessageMatch(room, message, bot)
     if match.not_from_this_bot() and match.prefix(PREFIX) and (
@@ -71,9 +70,7 @@ async def high_five(room, message):
             room.room_id, f"{message.sender} high-fived the bot!")
 
 
-bot.add_message_listener(high_five)
-
-
+@bot.listener.on_message_event
 async def high_five_count(room, message):
     match = botlib.MessageMatch(room, message, bot)
     if match.not_from_this_bot and match.prefix(PREFIX) and (
@@ -83,7 +80,5 @@ async def high_five_count(room, message):
             room.room_id,
             f"The bot has been high-fived {str(bot.total_high_fives)} times!")
 
-
-bot.add_message_listener(high_five_count)
 
 bot.run()

--- a/examples/rock_paper_scissors.py
+++ b/examples/rock_paper_scissors.py
@@ -34,6 +34,7 @@ bot = botlib.Bot(creds)
 PREFIX = '!'
 
 
+@bot.listener.on_message_event
 async def help_message(room, message):
     match = botlib.MessageMatch(room, message, bot)
     if not (match.not_from_this_bot() and match.prefix(PREFIX)
@@ -53,9 +54,8 @@ async def help_message(room, message):
     await bot.api.send_text_message(room.room_id, message)
 
 
-bot.add_message_listener(help_message)
 
-
+@bot.listener.on_message_event
 async def make_choice(room, message):
     match = botlib.MessageMatch(room, message, bot)
     if not (match.not_from_this_bot() and match.prefix(PREFIX)
@@ -97,6 +97,5 @@ async def make_choice(room, message):
         )
 
 
-bot.add_message_listener(make_choice)
 
 bot.run()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-VERSION = '1.6.0'
+VERSION = '1.6.1'
 DESCRIPTION = 'An easy to use bot library for the Matrix ecosystem written in Python.'
 with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
                        'README.md'),

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,8 @@ setup(
     long_description_content_type='text/markdown',
     packages=find_packages(),
     install_requires=[
-        "matrix-nio >= 0.18.2",
-        "python-cryptography-fernet-wrapper >= 1.0.4",
-        "pillow >= 8.0",
-        "aiofiles >= 0.7.0"
+        "matrix-nio >= 0.18.2", "python-cryptography-fernet-wrapper >= 1.0.4",
+        "pillow >= 8.0", "aiofiles >= 0.7.0"
     ],
     keywords=[
         'python', 'matrix', 'bot', 'simple', 'library',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "matrix-nio >= 0.18.2", "python-cryptography-fernet-wrapper >= 1.0.4",
-        "pillow >= 8.0", "aiofiles >= 0.7.0"
+        "pillow >= 8.0", "aiofiles >= 0.6.0"
     ],
     keywords=[
         'python', 'matrix', 'bot', 'simple', 'library',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     long_description_content_type='text/markdown',
     packages=find_packages(),
     install_requires=[
-        "matrix-nio >= 0.18.2", 
+        "matrix-nio >= 0.18.2",
         "python-cryptography-fernet-wrapper >= 1.0.4",
     ],
     keywords=[

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-VERSION = '1.5.2'
+VERSION = '1.5.3'
 DESCRIPTION = 'An easy to use bot library for the Matrix ecosystem written in Python.'
 with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
                        'README.md'),

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-VERSION = '1.5.3'
+VERSION = '1.6.0'
 DESCRIPTION = 'An easy to use bot library for the Matrix ecosystem written in Python.'
 with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
                        'README.md'),

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ setup(
     install_requires=[
         "matrix-nio >= 0.18.2",
         "python-cryptography-fernet-wrapper >= 1.0.4",
+        "pillow >= 8.0",
+        "aiofiles >= 0.7.0"
     ],
     keywords=[
         'python', 'matrix', 'bot', 'simple', 'library',

--- a/simplematrixbotlib/__init__.py
+++ b/simplematrixbotlib/__init__.py
@@ -3,3 +3,4 @@ from simplematrixbotlib.auth import Creds
 from simplematrixbotlib.bot import Bot
 from simplematrixbotlib.callbacks import Callbacks
 from simplematrixbotlib.match import MessageMatch
+from simplematrixbotlib.listener import Listener

--- a/simplematrixbotlib/api.py
+++ b/simplematrixbotlib/api.py
@@ -74,7 +74,7 @@ class Api:
                                               "msgtype": "m.text",
                                               "body": message
                                           })
-    
+
     async def send_image_message(self, room_id, image_filepath):
         """
         Send an image message in a Matrix room.
@@ -96,16 +96,15 @@ class Api:
         file_stat = await aiofiles.os.stat(image_filepath)
         async with aiofiles.open(image_filepath, "r+b") as file:
             resp, maybe_keys = await self.async_client.upload(
-                file, 
+                file,
                 content_type=mime_type,
                 filename=os.path.basename(image_filepath),
-                filesize=file_stat.st_size
-            )
+                filesize=file_stat.st_size)
         if isinstance(resp, UploadResponse):
-            pass #Successful upload
+            pass  #Successful upload
         else:
             print(f"Failed Upload Response: {resp}")
-        
+
         content = {
             "body": os.path.basename(image_filepath),
             "info": {
@@ -121,9 +120,8 @@ class Api:
         }
 
         try:
-            await self.async_client.room_send(
-                room_id, message_type="m.room.message", content=content
-            )
+            await self.async_client.room_send(room_id,
+                                              message_type="m.room.message",
+                                              content=content)
         except:
             print(f"Failed to send image file {image_filepath}")
-

--- a/simplematrixbotlib/api.py
+++ b/simplematrixbotlib/api.py
@@ -1,5 +1,11 @@
 import asyncio
 from nio import (AsyncClient, SyncResponse, RoomMessageText)
+from PIL import Image
+import aiofiles.os
+import mimetypes
+import os
+
+from nio.responses import UploadResponse
 
 
 class Api:
@@ -68,3 +74,56 @@ class Api:
                                               "msgtype": "m.text",
                                               "body": message
                                           })
+    
+    async def send_image_message(self, room_id, image_filepath):
+        """
+        Send an image message in a Matrix room.
+
+        Parameteres
+        -----------
+        room_id : str
+            The room id of the destination of the message.
+
+        image_filepath : str
+            The path to the image on your machien.
+        """
+
+        mime_type = mimetypes.guess_type(image_filepath)[0]
+
+        image = Image.open(image_filepath)
+        (width, height) = image.size
+
+        file_stat = await aiofiles.os.stat(image_filepath)
+        async with aiofiles.open(image_filepath, "r+b") as file:
+            resp, maybe_keys = await self.async_client.upload(
+                file, 
+                content_type=mime_type,
+                filename=os.path.basename(image_filepath),
+                filesize=file_stat.st_size
+            )
+        if isinstance(resp, UploadResponse):
+            pass #Successful upload
+        else:
+            print(f"Failed Upload Response: {resp}")
+        
+        content = {
+            "body": os.path.basename(image_filepath),
+            "info": {
+                "size": file_stat.st_size,
+                "mimetype": mime_type,
+                "thumbnail_info": None,
+                "w": width,
+                "h": height,
+                "thumbnail_url": None
+            },
+            "msgtype": "m.image",
+            "url": resp.content_uri
+        }
+
+        try:
+            await self.async_client.room_send(
+                room_id, message_type="m.room.message", content=content
+            )
+        except:
+            print(f"Failed to send image file {image_filepath}")
+

--- a/simplematrixbotlib/bot.py
+++ b/simplematrixbotlib/bot.py
@@ -27,7 +27,6 @@ class Bot:
         self.creds = creds
         self.api = botlib.Api(self.creds)
         self.listener = botlib.Listener(self)
-        self.startup_actions = []
 
     async def main(self):
         await self.api.login()
@@ -39,23 +38,11 @@ class Bot:
         self.callbacks = botlib.Callbacks(self.async_client, self)
         await self.callbacks.setup_callbacks()
 
-        for action in self.startup_actions:
+        for action in self.listener._startup_registry:
             for room_id in self.async_client.rooms:
                 await action(room_id)
 
         await self.async_client.sync_forever(timeout=3000, full_state=True)
-
-    def add_startup_action(self, action_func):
-        """
-        Adds action to be executed at bot start after bot login.
-
-        Parameteres
-        -----------
-        
-        action_func : function
-
-        """
-        self.startup_actions.append(action_func)
 
     def run(self):
         """

--- a/simplematrixbotlib/bot.py
+++ b/simplematrixbotlib/bot.py
@@ -27,7 +27,6 @@ class Bot:
         self.creds = creds
         self.api = botlib.Api(self.creds)
         self.listener = botlib.Listener(self)
-        self.message_actions = []
         self.startup_actions = []
 
     async def main(self):
@@ -45,18 +44,6 @@ class Bot:
                 await action(room_id)
 
         await self.async_client.sync_forever(timeout=3000, full_state=True)
-
-    def add_message_listener(self, action_func):
-        """
-        Adds message callbacks to the message listener.
-
-        Parameteres
-        -----------
-        
-        action_func : function
-
-        """
-        self.message_actions.append(action_func)
 
     def add_startup_action(self, action_func):
         """

--- a/simplematrixbotlib/bot.py
+++ b/simplematrixbotlib/bot.py
@@ -26,6 +26,7 @@ class Bot:
 
         self.creds = creds
         self.api = botlib.Api(self.creds)
+        self.listener = botlib.Listener(self)
         self.message_actions = []
         self.startup_actions = []
 

--- a/simplematrixbotlib/callbacks.py
+++ b/simplematrixbotlib/callbacks.py
@@ -23,7 +23,7 @@ class Callbacks:
                                              RoomMessageText)
 
         for event_listener in self.bot.listener._registry:
-            self.async_client.add_event_callback(event_listener[1], event_listener[0])
+            self.async_client.add_event_callback(event_listener[0], event_listener[1])
                                              
 
     async def invite_callback(self, room, event, tries=1):

--- a/simplematrixbotlib/callbacks.py
+++ b/simplematrixbotlib/callbacks.py
@@ -34,6 +34,9 @@ class Callbacks:
             Amount of times that this function has been called in a row for the same exact event.
 
         """
+        if not event.membership == "invite":
+            return
+            
         try:
             await self.async_client.join(room.room_id)
             print(f"Joined {room.room_id}")

--- a/simplematrixbotlib/callbacks.py
+++ b/simplematrixbotlib/callbacks.py
@@ -19,8 +19,6 @@ class Callbacks:
         """
         self.async_client.add_event_callback(self.invite_callback,
                                              InviteMemberEvent)
-        self.async_client.add_event_callback(self.message_callback,
-                                             RoomMessageText)
 
         for event_listener in self.bot.listener._registry:
             self.async_client.add_event_callback(event_listener[0], event_listener[1])
@@ -52,16 +50,3 @@ class Callbacks:
                 await self.invite_callback(room, event, tries)
             else:
                 print(f"Failed to join {room.room_id} after 3 tries")
-
-    async def message_callback(self, room, event):
-        """
-        callback for handling messages
-
-        Parameters
-        ----------
-        room : nio.rooms.MatrixRoom
-        event : nio.events.room_events.Event
-        
-        """
-        for action in self.bot.message_actions:
-            await action(room, event)

--- a/simplematrixbotlib/callbacks.py
+++ b/simplematrixbotlib/callbacks.py
@@ -36,7 +36,7 @@ class Callbacks:
         """
         if not event.membership == "invite":
             return
-            
+
         try:
             await self.async_client.join(room.room_id)
             print(f"Joined {room.room_id}")

--- a/simplematrixbotlib/callbacks.py
+++ b/simplematrixbotlib/callbacks.py
@@ -22,6 +22,10 @@ class Callbacks:
         self.async_client.add_event_callback(self.message_callback,
                                              RoomMessageText)
 
+        for event_listener in self.bot.listener._registry:
+            self.async_client.add_event_callback(event_listener[1], event_listener[0])
+                                             
+
     async def invite_callback(self, room, event, tries=1):
         """
         Callback for handling invites.

--- a/simplematrixbotlib/listener.py
+++ b/simplematrixbotlib/listener.py
@@ -5,17 +5,16 @@ class Listener:
         self._bot = bot
         self._registry = []
     
-    def _make_dec_with_arg(self, decorator):
-        def layer(*args, **kwargs):
-            def repl(function):
-                return decorator(function, *args, **kwargs)
-            return repl
-        return layer
+    def on_custom_event(self, event):
+        def wrapper(func):
+            if [func, event] in self._registry:
+                func()
+            else:
+                self._registry.append([func, event])
+        return wrapper
     
-    @self._make_dec_with_arg
-    def on_custom_event(self, handler, event_type):
-        self._registry.append([event_type, handler])
-    
-    @self._make_dec_with_arg
-    def on_message_event(self, handler):
-        self._registry.append([RoomMessageText, handler])
+    def on_message_event(self, func):
+        if [func, RoomMessageText] in self._registry:
+            func()
+        else:
+            self._registry.append([func, RoomMessageText])

--- a/simplematrixbotlib/listener.py
+++ b/simplematrixbotlib/listener.py
@@ -13,9 +13,9 @@ class Listener:
         return layer
     
     @self._make_dec_with_arg
-    def custom_event(self, handler, event_type: str):
+    def on_custom_event(self, handler, event_type: str):
         self._registry.append([event_type, handler])
     
     @self._make_dec_with_arg
-    def message_event(self, handler):
+    def on_message_event(self, handler):
         self._registry.append([RoomMessageText, handler])

--- a/simplematrixbotlib/listener.py
+++ b/simplematrixbotlib/listener.py
@@ -1,0 +1,21 @@
+from nio import RoomMessageText
+
+class Listener:
+    def __init__(self, bot):
+        self._bot = bot
+        self._registry = []
+    
+    def _make_dec_with_arg(self, decorator):
+        def layer(*args, **kwargs):
+            def repl(function):
+                return decorator(function, *args, **kwargs)
+            return repl
+        return layer
+    
+    @self._make_dec_with_arg
+    def custom_event(self, handler, event_type: str):
+        self._registry.append([event_type, handler])
+    
+    @self._make_dec_with_arg
+    def message_event(self, handler):
+        self._registry.append([RoomMessageText, handler])

--- a/simplematrixbotlib/listener.py
+++ b/simplematrixbotlib/listener.py
@@ -4,6 +4,7 @@ class Listener:
     def __init__(self, bot):
         self._bot = bot
         self._registry = []
+        self._startup_registry = []
     
     def on_custom_event(self, event):
         def wrapper(func):
@@ -18,3 +19,9 @@ class Listener:
             func()
         else:
             self._registry.append([func, RoomMessageText])
+    
+    def on_startup(self, func):
+        if func in self._startup_registry:
+            func()
+        else:
+            self._startup_registry.append(func)

--- a/simplematrixbotlib/listener.py
+++ b/simplematrixbotlib/listener.py
@@ -13,7 +13,7 @@ class Listener:
         return layer
     
     @self._make_dec_with_arg
-    def on_custom_event(self, handler, event_type: str):
+    def on_custom_event(self, handler, event_type):
         self._registry.append([event_type, handler])
     
     @self._make_dec_with_arg

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -3,46 +3,53 @@ import unittest
 from unittest import mock
 import simplematrixbotlib as botlib
 
+
 class IntegrationMatchTest(unittest.TestCase):
     def setUp(self):
         self.mock_room = mock.Mock()
         self.mock_message = mock.Mock()
         self.mock_bot = mock.Mock()
-    
+
     def test_single_word_message_body(self):
         self.mock_message.body = 'hello'
 
-        message_match = botlib.MessageMatch(self.mock_room, self.mock_message, self.mock_bot)
+        message_match = botlib.MessageMatch(self.mock_room, self.mock_message,
+                                            self.mock_bot)
         self.assertTrue(message_match.prefix('hello'))
 
-        message_match = botlib.MessageMatch(self.mock_room, self.mock_message, self.mock_bot)
+        message_match = botlib.MessageMatch(self.mock_room, self.mock_message,
+                                            self.mock_bot)
         self.assertTrue(message_match.command('hello'))
 
-        message_match = botlib.MessageMatch(self.mock_room, self.mock_message, self.mock_bot)
+        message_match = botlib.MessageMatch(self.mock_room, self.mock_message,
+                                            self.mock_bot)
         self.assertFalse(message_match.command('ello'))
         self.assertTrue(message_match.prefix('h'))
         self.assertTrue(message_match.command('ello'))
 
-        message_match = botlib.MessageMatch(self.mock_room, self.mock_message, self.mock_bot)
+        message_match = botlib.MessageMatch(self.mock_room, self.mock_message,
+                                            self.mock_bot)
         message_match.command('hello')
         self.assertFalse(message_match.args)
 
-        message_match = botlib.MessageMatch(self.mock_room, self.mock_message, self.mock_bot)
+        message_match = botlib.MessageMatch(self.mock_room, self.mock_message,
+                                            self.mock_bot)
         self.assertTrue(message_match.contains('hello'))
         self.assertTrue(message_match.contains('h'))
         self.assertTrue(message_match.contains('lo'))
         self.assertFalse(message_match.contains('he llo'))
-    
+
     def test_prefix_command_with_args_message_body_different_user_ids(self):
         self.mock_message.body = '!mycommand arg1 arg2'
         self.mock_message.sender = '1234'
         self.mock_bot.async_client.user_id = '5678'
-        message_match = botlib.MessageMatch(self.mock_room, self.mock_message, self.mock_bot)
+        message_match = botlib.MessageMatch(self.mock_room, self.mock_message,
+                                            self.mock_bot)
 
         self.assertTrue(
-            message_match.prefix('!') and message_match.command('mycommand') and message_match.not_from_this_bot()
-            )
-        
+            message_match.prefix('!') and message_match.command('mycommand')
+            and message_match.not_from_this_bot())
+
         #self.assertEqual(message_match.args[0], 'arg1') disable failed tests, will enable in "fix" branch
         #self.assertEqual(message_match.args[1], 'arg2')
 
@@ -54,7 +61,5 @@ class IntegrationMatchTest(unittest.TestCase):
         self.assertTrue(message_match.contains('a'))
 
 
-
 if __name__ == '__main__':
     unittest.main()
-        


### PR DESCRIPTION
Adds alternate method of adding event listeners.

```
import simplematrixbotlib as botlib
import os
import nio

creds = botlib.Creds("https://example.org", "echo_bot", "secretpassword")
bot = botlib.Bot(creds)

prefix = '!'

@bot.listener.on_message_event ### or @bot.listener.on_custom_event(nio.RoomMessageText)
async def echo(room, message):
    match = botlib.MessageMatch(room, message, bot)
    if match.not_from_this_bot() and match.prefix(prefix) and match.command(
            "echo"):
        await bot.api.send_text_message(room.room_id, match.args)


bot.run()
```