### PR TITLE
add bot trigger: mention

### DIFF
--- a/simplematrixbotlib/bot.py
+++ b/simplematrixbotlib/bot.py
@@ -39,7 +39,7 @@ class Bot:
 
 
         resp = await self.async_client.sync(timeout=65536,
-                                     full_state=False)  #Ignore prior messages
+                                     full_state=True)  #Ignore prior messages
 
         if isinstance(resp, SyncResponse):
             print(f"Connected to {self.async_client.homeserver} as {self.async_client.user_id} ({self.async_client.device_id})")


### PR DESCRIPTION
example:
```python
    match = botlib.MessageMatch(room, message, bot, conf.prefix)

    if match.is_not_from_this_bot() and (match.prefix() or match.mention()):
        if match.command('help') or match.command('h') or (match.mention() and match.command('?')):
            me = await bot.async_client.get_displayname()
            me = me.displayname
            help = f"use `!help {me}` or `{me}: help` to display detailed help."
            if match.mention() or (len(match.args()) > 0 and match.args()[0].lower() == me.lower()):
                help += "\n"
                help += f"you can interact with me by sending a message prefixed with `{conf.prefix}`, my name (`{me}`), or my full matrix ID.\n"
            await bot.api.send_markdown_message(room.room_id, help, 'm.notice')
```

![image](https://user-images.githubusercontent.com/2803622/142235549-8635d8f2-a6cf-4fcc-9f66-fb8d7077a26d.png)

works with pills, displayname, disambiguated disaplyname, full matrix ID.

However as-is, it needs a full sync to be able to resolve this (`users` can be empty otherwise):
https://github.com/KrazyKirby99999/simple-matrix-bot-lib/blob/33776bad9855c4337557d3badfe3af74e9c9af1a/simplematrixbotlib/match.py#L85

I don't thing that's optimal since a full sync on startup can take long when the account/room reached a certain lifetime. Is it possible to sync only the members list of the required room on demand?