### PR TITLE
add ability to reply with text messages

### DIFF
--- a/doc/manual/api.md
+++ b/doc/manual/api.md
@@ -16,11 +16,58 @@ async def example(room, message):
     example_message = "Hello World"
     if match.is_not_from_this_bot():
         await bot.api.send_text_message(
-            room_id=room.room_id, 
+            room_id=room.room_id,
+            message=example_message)
+```
+The first two arguments are required. The room_id argument is the id of the destination room. The message argument is the string that is to be sent as a message.
+
+#### Sending a bot notice
+To send a bot notice (non-alerting message), set the argument `msgtype="m.notice"`. It can be combined with any of the other optional arguments.
+```python
+async def example(room, message):
+    match = botlib.MessageMatch(room, message, bot)
+    example_message = "Hello World"
+    if match.is_not_from_this_bot():
+        await bot.api.send_text_message(
+            room_id=room.room_id,
             message=example_message,
             msgtype="m.notice")
 ```
-The first two arguments are required. The room_id argument is the id of the destination room. The message argument is the string that is to be sent as a message. The msgtype argument can be "m.text" (default) or "m.notice".
+
+#### Sending a reply
+To send your message as a reply to another message, pass the original message event to the `reply_to` argument. It can be combined with any of the other optional arguments.
+```python
+async def example(room, message):
+    match = botlib.MessageMatch(room, message, bot)
+    example_message = "Hello World"
+    if match.is_not_from_this_bot():
+        await bot.api.send_text_message(
+            room_id=room.room_id,
+            message=example_message,
+            reply_to=message)
+```
+
+#### Sending a markdown formatted message
+To translate markdown in your `example_message` into a HTML formatted message, set the argument `markdown=True`. It can be combined with any of the other optional arguments.
+```python
+async def example(room, message):
+    match = botlib.MessageMatch(room, message, bot)
+    example_message = "Hello World"
+    if match.is_not_from_this_bot():
+        await bot.api.send_text_message(
+            room_id=room.room_id,
+            message=example_message,
+            markdown=True)
+```
+
+Alternatively, use the send_markdown_message alias method, which also supports the other optional arguments:
+```python
+await bot.api.send_markdown_message(
+    room_id=room.room_id,
+    message=example_markdown,
+    msgtype="m.notice",
+    reply_to=message)
+```
 
 ### Using the send_image_message method
 The send_image_message method of the Api class can be used to send image messages in Matrix rooms. An example is shown in the following python code.
@@ -30,21 +77,7 @@ async def example(room, message):
     example_image="./img/example.png"
     if match.is_not_from_this_bot():
         await bot.api.send_image_message(
-            room_id=room.room_id, 
+            room_id=room.room_id,
             image_filepath=example_image)
 ```
 Both arguments are required. The room_id argument is the id of the destination room. The image_filepath argument is a string that is the path to the image file that is to be sent as a message.
-
-### Using the send_markdown_message method
-The send_markdown_message method of the Api class can be used to send markdown messages in Matrix rooms. An example is shown in the following python code.
-```python
-async def example(room, message):
-    match = botlib.MessageMatch(room, message, bot)
-    example_markdown = "# Hello World from [simplematrixbotlib](https://github.com/KrazyKirby99999/simple-matrix-bot-lib)!"
-    if match.is_not_from_this_bot():
-        await bot.api.send_markdown_message(
-            room_id=room.room_id, 
-            message=example_markdown,
-            msgtype="m.notice")
-```
-The first two arguments are required. The room_id argument is the id of the destination room. The message argument is the string with markdown syntax that is to be sent as a message. The msgtype argument can be "m.text" (default) or "m.notice".


### PR DESCRIPTION
I did refactor `send_markdown_message` along the way because it is almost identical to `send_text_message` and code reply and other would be doubled up otherwise. This should improve maintainability while staying compatible with earlier versions.

Sending replies isn't so bad, but receiving and reading replies correctly is a harder problem. I think it is reasonable to just not go there and wait for MSC2781 https://github.com/matrix-org/matrix-doc/pull/2781 to arrive at which point the issue would be resolved.

I also revised the manual to reflect the changes.