### PR TITLE
feat: :sparkles: configure who can use the bot

### DIFF
--- a/doc/manual/config.md
+++ b/doc/manual/config.md
@@ -1,5 +1,5 @@
 ### How to use the Config class
-The Config class is a class that handles whether or not certain features are enabled or disabled. The source is located at simplematrixbotlib/config.py
+The Config class is a class that handles whether certain features are enabled or disabled. The source is located at simplematrixbotlib/config.py
 
 #### Creating an instance of the Config class
 An instance can be created using the following python code.
@@ -14,9 +14,9 @@ config.load_toml("config.toml")
 ```
 Depending on the file format, a specific method may be used for reading the file. A table of the appropriate method to use for each format is shown below.
 
-| Format | Method          |
-|--------|-----------------|
-| TOML   | load_toml(file) |
+| Format | Method            |
+|--------|-------------------|
+| TOML   | `load_toml(file)` |
 
 Example configuration files for each file format can be under the examples section of the documentation. An example of a toml config file can be found [here](https://simple-matrix-bot-lib.readthedocs.io/en/latest/examples.html#bot-config-file-in-toml-format).
 
@@ -29,4 +29,8 @@ Depending on the setting, a specific method may be used for choosing the value. 
 
 | Method                      | Description                                  |
 |-----------------------------|----------------------------------------------|
-| set_join_on_invite(boolean) | Whether the bot should automatically join rooms on invite. |
+| `set_join_on_invite(boolean)` | Whether the bot should automatically join rooms on invite. |
+| `set_allowlist(list)` | Set the list of users who are allowed to interact with the bot. |
+| `add_allowlist(list)` | Merge this list into the list of users who are allowed to interact with the bot. |
+| `set_blocklist(list)` | Set the list of users who are disallowed to interact with the bot. |
+| `add_blocklist(list)` | Merge this list into the list of users who are disallowed to interact with the bot. |

--- a/doc/manual/config.md
+++ b/doc/manual/config.md
@@ -1,7 +1,22 @@
 ### How to use the Config class
 The Config class is a class that handles whether certain features are enabled or disabled. The source is located at simplematrixbotlib/config.py
 
+#### Creating an instance of the Config class
+An instance can be created using the following python code.
+```python
+config = botlib.Config()
+```
+
 #### Supported Values
+
+The following Config values may implement validation logic. They can be interacted with as if they were public member variables:
+```python
+config.join_on_invite = True
+print(c.join_on_invite)
+```
+
+See also: [Additional Methods](#additional-methods)
+
 ##### `join_on_invite`
 Boolean: whether the bot accepts all invites automatically.
 
@@ -18,15 +33,19 @@ Blocks user IDs on it if non-empty, even overriding the `allowlist`.
 For example: this way it is possible to allow all users from a homesever, but block single ones.
 You can check using `Match.is_from_allowed_user` if the sender of a command is allowed to use the bot and act accordingly.
 
-#### Creating an instance of the Config class
-An instance can be created using the following python code.
-```python
-creds = botlib.Config()
-```
+#### Additional methods
+Configuration settings can additionally be manipulated in special ways using the following methods.
 
-#### Reading config values from file
+| Method                   | Description                                                                            |
+|--------------------------|----------------------------------------------------------------------------------------|
+| `add_allowlist(list)`    | Merge this list into the list of users who are allowed to interact with the bot.       |
+| `remove_allowlist(list)` | Subtract this list from the list of users who are allowed to interact with the bot.    |
+| `add_blocklist(list)`    | Merge this list into the list of users who are disallowed to interact with the bot.    |
+| `remove_blocklist(list)` | Subtract this list from the list of users who are disallowed to interact with the bot. |
+
+#### Loading and saving config values
 Configuration settings can be set to values read from a file using the following python code.
-```
+```python
 config.load_toml("config.toml")
 ```
 Depending on the file format, a specific method may be used for reading the file. A table of the appropriate method to use for each format is shown below.
@@ -35,19 +54,13 @@ Depending on the file format, a specific method may be used for reading the file
 |--------|-------------------|
 | TOML   | `load_toml(file)` |
 
+Similarly, settings can be written to file after manipulating them at runtime.
+```python
+config.save_toml("config.toml")
+```
+
+| Format | Method            |
+|--------|-------------------|
+| TOML   | `save_toml(file)` |
+
 Example configuration files for each file format can be under the examples section of the documentation. An example of a toml config file can be found [here](https://simple-matrix-bot-lib.readthedocs.io/en/latest/examples.html#bot-config-file-in-toml-format).
-
-#### Manually setting config values
-Configuration settings can also be set manually using the following python code.
-```
-config.set_join_on_invite(False)
-```
-Depending on the setting, a specific method may be used for choosing the value. A table of the appropriate method to use for each setting is shown below.
-
-| Method                      | Description                                  |
-|-----------------------------|----------------------------------------------|
-| `set_join_on_invite(boolean)` | Whether the bot should automatically join rooms on invite. |
-| `set_allowlist(list)` | Set the list of users who are allowed to interact with the bot. |
-| `add_allowlist(list)` | Merge this list into the list of users who are allowed to interact with the bot. |
-| `set_blocklist(list)` | Set the list of users who are disallowed to interact with the bot. |
-| `add_blocklist(list)` | Merge this list into the list of users who are disallowed to interact with the bot. |

--- a/doc/manual/config.md
+++ b/doc/manual/config.md
@@ -1,6 +1,23 @@
 ### How to use the Config class
 The Config class is a class that handles whether certain features are enabled or disabled. The source is located at simplematrixbotlib/config.py
 
+#### Supported Values
+##### `join_on_invite`
+Boolean: whether the bot accepts all invites automatically.
+
+##### `allowlist`
+List of strings: [Regular expressions](https://docs.python.org/3/library/re.html) of matrix user IDs who are allowed to send commands to the bot.
+Defaults to allow everyone on the bot's homeserver.
+If the list is non-empty, user IDs that are not on it are blocked. Thus to allow anybody, set it to `[]`.
+You can check using `Match.is_from_allowed_user` if the sender of a command is allowed to use the bot and act accordingly.
+
+##### `blocklist`
+List of strings: [Regular expressions](https://docs.python.org/3/library/re.html) of matrix user IDs who are not allowed to send commands to the bot.
+Defaults to empty, blocking nobody.
+Blocks user IDs on it if non-empty, even overriding the `allowlist`.
+For example: this way it is possible to allow all users from a homesever, but block single ones.
+You can check using `Match.is_from_allowed_user` if the sender of a command is allowed to use the bot and act accordingly.
+
 #### Creating an instance of the Config class
 An instance can be created using the following python code.
 ```python

--- a/simplematrixbotlib/bot.py
+++ b/simplematrixbotlib/bot.py
@@ -27,11 +27,13 @@ class Bot:
         """
 
         self.creds = creds
+        self.api = botlib.Api(self.creds)
         if config:
             self.config = config
         else:
             self.config = botlib.Config()
-        self.api = botlib.Api(self.creds)
+            # allow (only) users from our own homeserver by default
+            self.config.set_allowlist([f'*:{self.api.async_client.user_id[self.api.async_client.user_id.index(":")+1:]}'])
         self.listener = botlib.Listener(self)
 
     async def main(self):

--- a/simplematrixbotlib/bot.py
+++ b/simplematrixbotlib/bot.py
@@ -33,7 +33,8 @@ class Bot:
         else:
             self.config = botlib.Config()
             # allow (only) users from our own homeserver by default
-            self.config.set_allowlist([f'*:{self.api.async_client.user_id[self.api.async_client.user_id.index(":")+1:]}'])
+            hs: str = self.api.async_client.user_id[self.api.async_client.user_id.index(":")+1:].replace('.', '\\.')
+            self.config.set_allowlist(set(f".*:{hs}"))
         self.listener = botlib.Listener(self)
 
     async def main(self):

--- a/simplematrixbotlib/callbacks.py
+++ b/simplematrixbotlib/callbacks.py
@@ -17,7 +17,7 @@ class Callbacks:
         Add callbacks to async_client
 
         """
-        if self.bot.config._join_on_invite:
+        if self.bot.config.join_on_invite:
             self.async_client.add_event_callback(self.invite_callback,
                                              InviteMemberEvent)
 

--- a/simplematrixbotlib/config.py
+++ b/simplematrixbotlib/config.py
@@ -3,7 +3,7 @@ import toml
 
 @dataclass
 class Config:
-    _join_on_invite: bool = True
+    join_on_invite: bool = True
     allowlist: list[str] = field(default_factory=list)  #TODO: default to bot's homeserver
     blocklist: list[str] = field(default_factory=list)
 
@@ -25,7 +25,7 @@ class Config:
             self._load_config_dict(config_dict)
     
     def set_join_on_invite(self, value: bool) -> None:
-        self._join_on_invite = value
+        self.join_on_invite = value
 
     def set_allowlist(self, value: list) -> None:
         self.allowlist = value

--- a/simplematrixbotlib/config.py
+++ b/simplematrixbotlib/config.py
@@ -1,13 +1,17 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import toml
 
 @dataclass
 class Config:
     _join_on_invite: bool = True
+    allowlist: list[str] = field(default_factory=list)  #TODO: default to bot's homeserver
+    blocklist: list[str] = field(default_factory=list)
 
     def _load_config_dict(self, config_dict: dict) -> None:
         _settings: dict = {
-            'join_on_invite': self.set_join_on_invite
+            'join_on_invite': self.set_join_on_invite,
+            'allowlist': self.set_allowlist,
+            'blocklist': self.set_blocklist
             }
             
         for key, value in config_dict.items():
@@ -23,4 +27,15 @@ class Config:
     
     def set_join_on_invite(self, value: bool) -> None:
         self._join_on_invite = value
-        
+
+    def set_allowlist(self, value: list) -> None:
+        self.allowlist = value
+
+    def add_allowlist(self, value: list) -> None:
+        self.allowlist = list(set(self.allowlist + value))
+
+    def set_blocklist(self, value: list) -> None:
+        self.blocklist = value
+
+    def add_blocklist(self, value: list) -> None:
+        self.blocklist = list(set(self.blocklist + value))

--- a/simplematrixbotlib/config.py
+++ b/simplematrixbotlib/config.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass, field
 import toml
+import re
 
 @dataclass
 class Config:
     join_on_invite: bool = True
-    allowlist: list[str] = field(default_factory=list)  #TODO: default to bot's homeserver
-    blocklist: list[str] = field(default_factory=list)
+    allowlist: set[str] = field(default_factory=set)  #TODO: default to bot's homeserver
+    blocklist: set[str] = field(default_factory=set)
 
     def _load_config_dict(self, config_dict: dict) -> None:
         _settings: dict = {
@@ -18,7 +19,6 @@ class Config:
             if key in _settings.keys():
                 _settings[key](value)
 
-
     def load_toml(self, file_path: str) -> None:
         with open(file_path, 'r') as file:
             config_dict: dict = toml.load(file)['simplematrixbotlib']['config']
@@ -27,14 +27,14 @@ class Config:
     def set_join_on_invite(self, value: bool) -> None:
         self.join_on_invite = value
 
-    def set_allowlist(self, value: list) -> None:
-        self.allowlist = value
+    def set_allowlist(self, value: set[str]) -> None:
+        self.allowlist = set(map(re.compile, value))
 
-    def add_allowlist(self, value: list) -> None:
-        self.allowlist = list(set(self.allowlist + value))
+    def add_allowlist(self, value: set[str]) -> None:
+        self.allowlist = self.allowlist.union(set(map(re.compile, value)))
 
-    def set_blocklist(self, value: list) -> None:
-        self.blocklist = value
+    def set_blocklist(self, value: set[str]) -> None:
+        self.blocklist = set(map(re.compile, value))
 
-    def add_blocklist(self, value: list) -> None:
-        self.blocklist = list(set(self.blocklist + value))
+    def add_blocklist(self, value: set[str]) -> None:
+        self.blocklist = self.blocklist.union(set(map(re.compile, value)))

--- a/simplematrixbotlib/config.py
+++ b/simplematrixbotlib/config.py
@@ -21,8 +21,7 @@ class Config:
 
     def load_toml(self, file_path: str) -> None:
         with open(file_path, 'r') as file:
-            toml_content: str = file.read()
-            config_dict: dict = toml.loads(toml_content)['simplematrixbotlib']['config']
+            config_dict: dict = toml.load(file)['simplematrixbotlib']['config']
             self._load_config_dict(config_dict)
     
     def set_join_on_invite(self, value: bool) -> None:

--- a/simplematrixbotlib/config.py
+++ b/simplematrixbotlib/config.py
@@ -4,37 +4,135 @@ import re
 
 @dataclass
 class Config:
-    join_on_invite: bool = True
-    allowlist: set[str] = field(default_factory=set)  #TODO: default to bot's homeserver
-    blocklist: set[str] = field(default_factory=set)
+    _join_on_invite: bool = True
+    _allowlist: set[str] = field(default_factory=set)  #TODO: default to bot's homeserver
+    _blocklist: set[str] = field(default_factory=set)
+
+    def _check_set_regex(self, value: set[str]) -> set[re.Pattern]:
+        new_list = set()
+        # loop value
+        for v in value:
+            # try re.compile
+            try:
+                tmp = re.compile(v)
+            # except return False
+            except re.error:
+                print(f"{v} is not a valid regular expression. Ignoring your list update.")
+                return
+            new_list.add(tmp)
+        return new_list
 
     def _load_config_dict(self, config_dict: dict) -> None:
-        _settings: dict = {
-            'join_on_invite': self.set_join_on_invite,
-            'allowlist': self.set_allowlist,
-            'blocklist': self.set_blocklist
-            }
-            
         for key, value in config_dict.items():
-            if key in _settings.keys():
-                _settings[key](value)
+            if key == 'join_on_invite':
+                self.join_on_invite = value
+            elif key == 'allowlist':
+                self.allowlist = value
+            elif key == 'blocklist':
+                self.blocklist = value
 
     def load_toml(self, file_path: str) -> None:
         with open(file_path, 'r') as file:
             config_dict: dict = toml.load(file)['simplematrixbotlib']['config']
             self._load_config_dict(config_dict)
-    
-    def set_join_on_invite(self, value: bool) -> None:
-        self.join_on_invite = value
 
-    def set_allowlist(self, value: set[str]) -> None:
-        self.allowlist = set(map(re.compile, value))
+
+    @property
+    def join_on_invite(self) -> bool:
+        """
+        Returns
+        -------
+        boolean
+            Whether the bot is configured to automatically accept all invites it receives
+        """
+        return self._join_on_invite
+
+    @join_on_invite.setter
+    def join_on_invite(self, value: bool) -> None:
+        self._join_on_invite = value
+
+    @property
+    def allowlist(self) -> set[str]:
+        """
+        Returns
+        -------
+        set[str]
+            A set of strings which represent Matrix IDs or a regular expression matching Matrix IDs.
+            Can be used in conjunction with blocklist to check if the sender is allowed to issue a command to the bot.
+            An empty set implies that everyone is allowed.
+        """
+        return self._allowlist
+
+    @allowlist.setter
+    def allowlist(self, value: set[str]) -> None:
+        # TODO rebase onto new master with working pytest
+        checked = self._check_set_regex(value)
+        if checked is None:
+            return
+        self._allowlist = checked
 
     def add_allowlist(self, value: set[str]) -> None:
-        self.allowlist = self.allowlist.union(set(map(re.compile, value)))
+        """
+        Parameters
+        ----------
+        value : set[str]
+            A set of strings which represent Matrix IDs or a regular expression matching Matrix IDs to be added to allowlist.
+        """
+        checked = self._check_set_regex(value)
+        if checked is None:
+            return
+        self._allowlist = self._allowlist.union(checked)
 
-    def set_blocklist(self, value: set[str]) -> None:
-        self.blocklist = set(map(re.compile, value))
+    def remove_allowlist(self, value: set[str]) -> None:
+        """
+        Parameters
+        ----------
+        value : set[str]
+            A set of strings which represent Matrix IDs or a regular expression matching Matrix IDs to be removed from allowlist.
+        """
+        checked = self._check_set_regex(value)
+        if checked is None:
+            return
+        self._allowlist = self._allowlist - checked
+
+    @property
+    def blocklist(self) -> set[str]:
+        """
+        Returns
+        -------
+        set[str]
+            A set of strings which represent Matrix IDs or a regular expression matching Matrix IDs.
+            Can be used in conjunction with allowlist to check if the sender is disallowed to issue a command to the bot.
+        """
+        return self._blocklist
+
+    @blocklist.setter
+    def blocklist(self, value: set[str]) -> None:
+        checked = self._check_set_regex(value)
+        if checked is None:
+            return
+        self._blocklist = checked
 
     def add_blocklist(self, value: set[str]) -> None:
-        self.blocklist = self.blocklist.union(set(map(re.compile, value)))
+        """
+        Parameters
+        ----------
+        value : set[str]
+            A set of strings which represent Matrix IDs or a regular expression matching Matrix IDs to be added to blocklist.
+        """
+        checked = self._check_set_regex(value)
+        if checked is None:
+            return
+        self._blocklist = self._blocklist.union(checked)
+
+    def remove_blocklist(self, value: set[str]) -> None:
+        """
+        Parameters
+        ----------
+        value : set[str]
+            A set of strings which represent Matrix IDs or a regular expression matching Matrix IDs to be removed from blocklist.
+        """
+        checked = self._check_set_regex(value)
+        if checked is None:
+            return
+        self._blocklist = self._blocklist - checked

--- a/simplematrixbotlib/match.py
+++ b/simplematrixbotlib/match.py
@@ -1,4 +1,3 @@
-import re
 
 class Match:
     """
@@ -56,18 +55,15 @@ class Match:
         # if there is no explicit allowlist, default to allow
         is_allowed = False if len(allowlist) > 0 else True
 
-        try:
-            for id in allowlist:
-                if re.fullmatch(id, sender):
-                    is_allowed = True
-                    break
-            for id in blocklist:
-                if re.fullmatch(id, sender):
-                    is_allowed = False
-                    break
-        except re.error as e:
-            print(f"invalid regular expression {e.pattern} (column {e.colno}")
-            return False
+        for regex in allowlist:
+            if regex.fullmatch(sender):
+                is_allowed = True
+                break
+
+        for regex in blocklist:
+            if regex.fullmatch(sender):
+                is_allowed = False
+                break
 
         return is_allowed
 

--- a/simplematrixbotlib/match.py
+++ b/simplematrixbotlib/match.py
@@ -1,3 +1,5 @@
+import re
+
 class Match:
     """
     Class with methods to filter events
@@ -40,6 +42,34 @@ class Match:
             Returns True if the event was sent from the specified userid
         """
         return self.event.sender == userid
+
+    def is_from_allowed_user(self):
+        """
+        Returns
+        -------
+        boolean
+            Returns True if the event was sent from an allowed userid
+        """
+        allowlist = self._bot.config.allowlist
+        blocklist = self._bot.config.blocklist
+        sender = self.event.sender
+        # if there is no explicit allowlist, default to allow
+        is_allowed = False if len(allowlist) > 0 else True
+
+        try:
+            for id in allowlist:
+                if re.fullmatch(id, sender):
+                    is_allowed = True
+                    break
+            for id in blocklist:
+                if re.fullmatch(id, sender):
+                    is_allowed = False
+                    break
+        except re.error as e:
+            print(f"invalid regular expression {e.pattern} (column {e.colno}")
+            return False
+
+        return is_allowed
 
     def is_not_from_this_bot(self):
         """

--- a/tests/config/sample_config_files/config1.toml
+++ b/tests/config/sample_config_files/config1.toml
@@ -1,4 +1,4 @@
 [simplematrixbotlib.config]
 join_on_invite = false
-allowlist = [".*:example\\.org", "@test:matrix.org"]
-blocklist = ["@test2:example.org"]
+allowlist = [".*:example\\.org", "@test:matrix\\.org"]
+blocklist = ["@test2:example\\.org"]

--- a/tests/config/sample_config_files/config1.toml
+++ b/tests/config/sample_config_files/config1.toml
@@ -1,2 +1,4 @@
 [simplematrixbotlib.config]
 join_on_invite = false
+allowlist = [".*:example\\.org", "@test:matrix.org"]
+blocklist = ["@test2:example.org"]

--- a/tests/config/sample_config_files/config4.toml
+++ b/tests/config/sample_config_files/config4.toml
@@ -1,0 +1,2 @@
+[simplematrixbotlib.config]
+blocklist = ["*"]

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -10,8 +10,8 @@ def test_defaults():
     config = botlib.Config()
 
     assert config.join_on_invite
-    assert config.allowlist == list()
-    assert config.blocklist == list()
+    assert config.allowlist == set()
+    assert config.blocklist == set()
 
 def test_read_toml():
     config = botlib.Config()
@@ -30,15 +30,34 @@ def test_read_toml():
 
     config = botlib.Config()
     # config4.toml uses invalid regular expression syntax
-    with pytest.raises(re.error):
-        assert config.load_toml(os.path.join(sample_config_path, 'config4.toml'))
+    config.load_toml(os.path.join(sample_config_path, 'config4.toml'))
+    assert config.blocklist == set()
 
     # TODO: test botlib.Bot() constructor creating a default Config
 
 def test_manual_set():
     config = botlib.Config()
-    config.set_join_on_invite(True)
+    config.join_on_invite = True
     assert config.join_on_invite
 
-    config.set_join_on_invite(False)
+    config.join_on_invite = False
     assert not config.join_on_invite
+
+    config = botlib.Config()
+    config.allowlist = {'.*:example\\.org'}
+    assert re.compile('.*:example\\.org') in config.allowlist
+    config.add_allowlist({'@test:matrix\\.org'})
+    assert config.allowlist == set(map(re.compile, ['.*:example\\.org', '@test:matrix\\.org']))
+    config.remove_allowlist({'.*:example\\.org'})
+    assert config.allowlist == set(map(re.compile, ['@test:matrix\\.org']))
+    config.allowlist = {'*:example\\.org'}
+    assert config.allowlist == set(map(re.compile, ['@test:matrix\\.org']))
+
+    config.blocklist = {'.*:example\\.org'}
+    assert re.compile('.*:example\\.org') in config.blocklist
+    config.add_blocklist({'@test:matrix\\.org'})
+    assert config.blocklist == set(map(re.compile, ['.*:example\\.org', '@test:matrix\\.org']))
+    config.remove_blocklist({'.*:example\\.org'})
+    assert config.blocklist == set(map(re.compile, ['@test:matrix\\.org']))
+    config.blocklist = {'*:example\\.org'}
+    assert config.blocklist == set(map(re.compile, ['@test:matrix\\.org']))

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -7,29 +7,29 @@ sample_config_path = os.path.join(pathlib.Path(__file__).parent, 'sample_config_
 def test_defaults():
     config = botlib.Config()
 
-    assert config._join_on_invite
+    assert config.join_on_invite
     assert config.allowlist == list()
     assert config.blocklist == list()
 
 def test_read_toml():
     config = botlib.Config()
-    assert not config._join_on_invite
     config.load_toml(os.path.join(sample_config_path, 'config1.toml'))
+    assert not config.join_on_invite
     assert config.allowlist == ['*:example.org', '@test:matrix.org']
     assert config.blocklist == ['@test2:example.org']
         
     config = botlib.Config()
-    assert config._join_on_invite
     config.load_toml(os.path.join(sample_config_path, 'config2.toml'))
+    assert config.join_on_invite
 
     config = botlib.Config()
-    assert config._join_on_invite
     config.load_toml(os.path.join(sample_config_path, 'config3.toml'))
+    assert config.join_on_invite
 
 def test_manual_set():
     config = botlib.Config()
     config.set_join_on_invite(True)
-    assert config._join_on_invite
+    assert config.join_on_invite
 
     config.set_join_on_invite(False)
-    assert not config._join_on_invite
+    assert not config.join_on_invite

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,6 +1,8 @@
 import pathlib
+import pytest
 import simplematrixbotlib as botlib
 import os.path
+import re
 
 sample_config_path = os.path.join(pathlib.Path(__file__).parent, 'sample_config_files')
 
@@ -15,8 +17,8 @@ def test_read_toml():
     config = botlib.Config()
     config.load_toml(os.path.join(sample_config_path, 'config1.toml'))
     assert not config.join_on_invite
-    assert config.allowlist == ['*:example.org', '@test:matrix.org']
-    assert config.blocklist == ['@test2:example.org']
+    assert set(config.allowlist) == set(map(re.compile, ['.*:example\\.org', '@test:matrix\\.org']))
+    assert set(config.blocklist) == set(map(re.compile, ['@test2:example\\.org']))
         
     config = botlib.Config()
     config.load_toml(os.path.join(sample_config_path, 'config2.toml'))
@@ -25,6 +27,13 @@ def test_read_toml():
     config = botlib.Config()
     config.load_toml(os.path.join(sample_config_path, 'config3.toml'))
     assert config.join_on_invite
+
+    config = botlib.Config()
+    # config4.toml uses invalid regular expression syntax
+    with pytest.raises(re.error):
+        assert config.load_toml(os.path.join(sample_config_path, 'config4.toml'))
+
+    # TODO: test botlib.Bot() constructor creating a default Config
 
 def test_manual_set():
     config = botlib.Config()

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,8 +1,8 @@
 import pathlib
 import simplematrixbotlib as botlib
+import os.path
 
-
-sample_config_path = f'{pathlib.Path(__file__).parent}/sample_config_files'
+sample_config_path = os.path.join(pathlib.Path(__file__).parent, 'sample_config_files')
 
 def test_defaults():
     config = botlib.Config()
@@ -13,18 +13,18 @@ def test_defaults():
 
 def test_read_toml():
     config = botlib.Config()
-    config.load_toml(f'{sample_config_path}/config1.toml')
     assert not config._join_on_invite
+    config.load_toml(os.path.join(sample_config_path, 'config1.toml'))
     assert config.allowlist == ['*:example.org', '@test:matrix.org']
     assert config.blocklist == ['@test2:example.org']
         
     config = botlib.Config()
-    config.load_toml(f'{sample_config_path}/config2.toml')
     assert config._join_on_invite
+    config.load_toml(os.path.join(sample_config_path, 'config2.toml'))
 
     config = botlib.Config()
-    config.load_toml(f'{sample_config_path}/config3.toml')
     assert config._join_on_invite
+    config.load_toml(os.path.join(sample_config_path, 'config3.toml'))
 
 def test_manual_set():
     config = botlib.Config()

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -8,11 +8,15 @@ def test_defaults():
     config = botlib.Config()
 
     assert config._join_on_invite
+    assert config.allowlist == list()
+    assert config.blocklist == list()
 
 def test_read_toml():
     config = botlib.Config()
     config.load_toml(f'{sample_config_path}/config1.toml')
     assert not config._join_on_invite
+    assert config.allowlist == ['*:example.org', '@test:matrix.org']
+    assert config.blocklist == ['@test2:example.org']
         
     config = botlib.Config()
     config.load_toml(f'{sample_config_path}/config2.toml')

--- a/tests/match/test_match.py
+++ b/tests/match/test_match.py
@@ -1,5 +1,7 @@
 from simplematrixbotlib.match import Match
+from simplematrixbotlib.config import Config
 from unittest import mock
+import pathlib, os.path
 
 mock_room = mock.MagicMock()
 
@@ -11,6 +13,10 @@ mock_bot.async_client.user_id = "botid"
 
 match = Match(mock_room, mock_event, mock_bot)
 
+match_config = Match(mock_room, mock_event, mock_bot)
+match_config._bot.config = Config()
+match_config._bot.config.load_toml(os.path.join(pathlib.Path(__file__).parent.parent, 'config', 'sample_config_files', 'config1.toml'))
+
 def test_init():
     assert isinstance(match.room, mock.MagicMock)
     assert isinstance(match.event, mock.MagicMock)
@@ -19,6 +25,19 @@ def test_init():
 def test_is_from_userid():
     assert match.is_from_userid("123")
     assert not match.is_from_userid("456")
+
+def test_allow_block():
+    match_config.event.sender = "@test:example.org"
+    assert match_config.is_from_allowed_user()
+
+    match_config.event.sender = "@test2:example.org"
+    assert not match_config.is_from_allowed_user()
+
+    match_config.event.sender = "@test:matrix.org"
+    assert match_config.is_from_allowed_user()
+
+    match_config.event.sender = "@test2:matrix.org"
+    assert not match_config.is_from_allowed_user()
 
 def test_is_not_from_this_bot():
     assert match.is_not_from_this_bot()


### PR DESCRIPTION
(security feature)
adds ability to check if a user is allowed to send a command to the bot via preset lists in the configuration file.

fixes #91 